### PR TITLE
Link to RSS feed in <head>

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400|Montserrat:500,700|Ubuntu+Mono" rel="stylesheet">
     <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+    <link rel="alternate" type="application/rss+xml"  href="https://blog.notionjs.com/feed.xml" title="{{ site.title }}">
     
     {% if jekyll.environment == 'production' and site.google_analytics %}
     {% include google-analytics.html %}


### PR DESCRIPTION
Link to the RSS feed added in https://github.com/notion-cli/blog/pull/1 to help feed readers and user agents auto-discover it.