### PR TITLE
Increase vibrancy and fix a color declaration.

### DIFF
--- a/_sass/notion/_alerts.scss
+++ b/_sass/notion/_alerts.scss
@@ -1,6 +1,6 @@
 .alert.alert-warn {
     background-color: rgba(255,229,100,.3);
-    color-primary-very-light: #e7c000;
+    border-color: #e7c000;
     color: #6b5900;
     padding: .1rem 1.5rem;
     border-left-width: .5rem;

--- a/_sass/notion/_constants.scss
+++ b/_sass/notion/_constants.scss
@@ -3,7 +3,7 @@ $color-primary: hsl(210, 40%, 48%);
 $color-primary-light: hsl(210, 40%, 60%);
 $color-primary-very-dark: hsl(210, 40%, 12%);
 $color-primary-dark: hsl(210, 40%, 36%);
-$color-secondary: hsl(345, 25%, 50%);
+$color-secondary: hsl(345, 45%, 53%);
 $color-secondary-dark: hsl(345, 25%, 25%);
 $color-primary-very-light: hsl(210, 40%, 93%);
 $code-bg-color: #262626; // match the syntax-highlighting

--- a/_sass/notion/_constants.scss
+++ b/_sass/notion/_constants.scss
@@ -14,6 +14,8 @@ $navbar-height: 3.6rem;
 $sidebar-width: 20rem;
 $content-width: 740px;
 
+$link-shift: 0.2em;
+
 // responsive breakpoints
 $media-narrow: 959px;
 $media-mobile: 719px;

--- a/_sass/notion/_layout.scss
+++ b/_sass/notion/_layout.scss
@@ -352,6 +352,22 @@ main.home .page-contents {
   span.next {
     float: right;
   }
+
+  a {
+    transition: 0.2s all;
+
+    &:hover {
+      color: $color-secondary;
+    }
+  }
+
+  .next a:hover {
+    margin-right: $link-shift;
+  }
+
+  .prev a:hover {
+    margin-left: $link-shift;
+  }
 }
 
 @media (max-width: $media-mobile) {
@@ -485,7 +501,7 @@ h1.blog-excerpt-title, h1.post-title {
   }
 
   .sidebar-heading {
-    color: #999;
+    color: #707070;
     transition: color .15s ease;
     cursor: pointer;
     font-size: 1.1em;
@@ -514,9 +530,15 @@ h1.blog-excerpt-title, h1.post-title {
     padding: 0.35rem 1rem 0.35rem 1.25rem;
     line-height: 1.4;
     width: 100%;
+    transition: 0.2s all;
     &:hover {
-      color: $color-primary;
+      color: $color-secondary;
     }
+
+    &:not(.active):hover {
+      margin-left: $link-shift;
+    }
+
     &.active {
       font-weight: 600;
       color: $color-primary;


### PR DESCRIPTION
- bumps the vibrancy of the reddish accent color (one thing might be a nice touch: using this as the hover color for links throughout the site, e.g. on the docs page. I can push that along as well if you like)
- fixes the bad CSS rule I introduced in #1

<details><summary>mobile</summary>
<img width="296" alt="screen shot 2019-02-06 at 19 36 05" src="https://user-images.githubusercontent.com/2403023/52389173-02d3f280-2a47-11e9-9117-f390eed842ff.png">
</details>

<details><summary>desktop</summary>
<img width="1275" alt="screen shot 2019-02-06 at 19 37 34" src="https://user-images.githubusercontent.com/2403023/52389174-02d3f280-2a47-11e9-90cc-fb4e7ac39047.png">
</details>